### PR TITLE
remove System.out.println debug call

### DIFF
--- a/src/main/java/com/voximplant/apiclient/VoximplantAPIClientImpl.java
+++ b/src/main/java/com/voximplant/apiclient/VoximplantAPIClientImpl.java
@@ -71,7 +71,7 @@ class VoximplantAPIClientImpl {
         builder.setHeader(headers);
         builder.signWith(SignatureAlgorithm.RS256, this.privateKey);
         String ss = builder.compact();
-        System.out.println("token generated");
+        
         return "Bearer "+ss;
     }
 


### PR DESCRIPTION
There apparently is debug call left in the code. This either should be removed or it should use standard logging method so it could be surpressed by configuration.